### PR TITLE
[ENHANCEMENT-1] Verbose debug flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Invalid ordering_flag option will lead to an error message and program exit.
 
 ### Two options: debug_flag, ordering_flag
 ```python3 main.py true 'BC_A'```
-debug_flag can take values of 'True', 'true', 'TRUE' or 'False', 'false', 'FALSE'
+debug_flag can take values of 'True', 'true', 'TRUE', 'debug=True' or 'False', 'false', 'FALSE', 'debug=False'
 Invalid debug_flag option will lead to to an error message and program exit.
 Running in debug mode will show additional logging to demonstrate the state of the algorithm.
 

--- a/algo/input.py
+++ b/algo/input.py
@@ -12,9 +12,9 @@ def validate_ordering_input(s):
     return True
 
 def validate_debug_input(s):
-    if s == "True" or s == "true" or s == "TRUE":	
+    if s == "True" or s == "true" or s == "TRUE" or s == "debug=True":
         return 1
-    if s == "False" or s == "false" or s == "FALSE":
+    if s == "False" or s == "false" or s == "FALSE" or s == "debug=False":
         return 2
     else:
         print("Error: Invalid debug flag")


### PR DESCRIPTION
Change:
Allow for passing `debug=True` and `debug=False` as the debug_flag during command line usage

Closes: https://github.com/anuragkalra/robot-arm/issues/1

New behavior:

```
$python3 main.py debug=True 'BC_A'

Running debug mode...
Input:    BC_A
Numeric Tokens:   [2, 3, 4, 1]
Cycles:   [[2, 3, 4, 1]]
Removing Cycle:   [2, 3, 4, 1]
1,2
['B', '_', 'C', 'A']
0,1
['_', 'B', 'C', 'A']
3,0
['A', 'B', 'C', '_']

$python3 main.py debug=False 'BC_A'

1,2
0,1
3,0
```

Tests:
```
$python3 test_algo.py -b

......
----------------------------------------------------------------------
Ran 6 tests in 0.001s

OK
```